### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Normalize all text to LF in the repo and in the working tree.
+* text=auto eol=lf
+
+# Windows-only scripts must stay CRLF.
+*.bat  text eol=crlf
+*.cmd  text eol=crlf
+
+# Binary assets: never touch line endings.
+*.jar    binary
+*.png    binary
+*.jpg    binary
+*.gif    binary
+*.ico    binary
+*.docx   binary
+*.xlsx   binary
+*.zip    binary
+*.gz     binary
+*.exe    binary
+*.dll    binary


### PR DESCRIPTION
## What
Adds a `.gitattributes` that normalizes text to LF in the repository (CRLF only for Windows `.bat`/`.cmd`; binaries untouched).

## Why
The repo had no `.gitattributes` and `core.autocrlf` is unset, so Windows checkouts silently rewrote files to CRLF, surfacing the entire tree as modified and otherwise burying real changes under line-ending churn. The repository is already stored as LF, so **no existing file contents change** — this PR is just the normalization policy.

## Notes
Two follow-up PRs are stacked on this one (OspreySharp feature, then installer + CI). Merging this first keeps their diffs clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized line endings across the repository for text files, helping reduce cross-platform formatting issues.
  * Preserved Windows-style endings for batch scripts and protected binary files from unintended line-ending changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->